### PR TITLE
Consolidate config/ and configs/ into single directory

### DIFF
--- a/src/plsec/commands/install.py
+++ b/src/plsec/commands/install.py
@@ -317,7 +317,7 @@ def deploy_global_configs(
         )
 
     # Deploy built-in preset TOML files
-    preset_dest = plsec_home / "config" / "presets"
+    preset_dest = plsec_home / "configs" / "presets"
     for toml_file in sorted(BUILTIN_PRESET_DIR.glob("*.toml")):
         _deploy_file(preset_dest / toml_file.name, toml_file.read_text(), force=force)
 

--- a/src/plsec/core/config.py
+++ b/src/plsec/core/config.py
@@ -513,7 +513,7 @@ def resolve_config(
 
     Resolution hierarchy (low to high priority):
     1. Defaults (PlsecConfig factory defaults)
-    2. Preset file (~/.peerlabs/plsec/config/presets/{preset}.toml or built-in)
+    2. Preset file (~/.peerlabs/plsec/configs/presets/{preset}.toml or built-in)
     3. Global config (~/.peerlabs/plsec/plsec.toml)
     4. Project config (./plsec.toml or ancestor directories)
     5. CLI arguments (highest priority)

--- a/src/plsec/core/health.py
+++ b/src/plsec/core/health.py
@@ -19,9 +19,8 @@ from plsec.core.tools import Tool, ToolStatus
 
 # Expected subdirectories under ~/.peerlabs/plsec/
 PLSEC_SUBDIRS: list[str] = [
-    "config",
-    "config/presets",
     "configs",
+    "configs/presets",
     "logs",
     "manifests",
     "trivy",
@@ -39,10 +38,10 @@ PLSEC_EXPECTED_FILES: list[tuple[str, str]] = [
 # Expected preset TOML files deployed by plsec install.
 # Each tuple is (relative_path, human_description).
 PLSEC_EXPECTED_PRESETS: list[tuple[str, str]] = [
-    ("config/presets/minimal.toml", "Minimal security preset"),
-    ("config/presets/balanced.toml", "Balanced security preset"),
-    ("config/presets/strict.toml", "Strict security preset"),
-    ("config/presets/paranoid.toml", "Paranoid security preset"),
+    ("configs/presets/minimal.toml", "Minimal security preset"),
+    ("configs/presets/balanced.toml", "Balanced security preset"),
+    ("configs/presets/strict.toml", "Strict security preset"),
+    ("configs/presets/paranoid.toml", "Paranoid security preset"),
 ]
 
 # Expected executable scripts deployed by plsec install.

--- a/src/plsec/core/presets.py
+++ b/src/plsec/core/presets.py
@@ -6,7 +6,7 @@ postures. Users can select presets via CLI (--preset) or config files
 
 Presets are stored as TOML files in two locations:
   1. Built-in presets: src/plsec/configs/presets/ (shipped with package)
-  2. User presets: ~/.peerlabs/plsec/config/presets/ (custom user presets)
+  2. User presets: ~/.peerlabs/plsec/configs/presets/ (custom user presets)
 
 User presets take precedence over built-in presets with the same name.
 
@@ -46,7 +46,7 @@ def get_user_preset_dir() -> Path:
     """Return the path to user custom preset directory."""
     from plsec.core.config import get_plsec_home
 
-    return get_plsec_home() / "config" / "presets"
+    return get_plsec_home() / "configs" / "presets"
 
 
 def find_preset_file(name: str) -> Path | None:
@@ -54,7 +54,7 @@ def find_preset_file(name: str) -> Path | None:
     Find a preset TOML file by name.
 
     Search order:
-      1. User preset directory (~/.peerlabs/plsec/config/presets/{name}.toml)
+      1. User preset directory (~/.peerlabs/plsec/configs/presets/{name}.toml)
       2. Built-in preset directory (src/plsec/configs/presets/{name}.toml)
 
     Args:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -676,7 +676,7 @@ class TestCheckPresetFiles:
     def test_partial_files(self, tmp_path: Path):
         """Some presets present, others missing -- mixed verdicts."""
         home = tmp_path / "plsec"
-        preset_dir = home / "config" / "presets"
+        preset_dir = home / "configs" / "presets"
         preset_dir.mkdir(parents=True)
         (preset_dir / "balanced.toml").write_text("[layers.static]\nenabled = true\n")
         results = check_preset_files(home)
@@ -687,10 +687,10 @@ class TestCheckPresetFiles:
     def test_expected_presets_constant(self):
         """PLSEC_EXPECTED_PRESETS should contain all four preset files."""
         names = [name for name, _ in PLSEC_EXPECTED_PRESETS]
-        assert "config/presets/minimal.toml" in names
-        assert "config/presets/balanced.toml" in names
-        assert "config/presets/strict.toml" in names
-        assert "config/presets/paranoid.toml" in names
+        assert "configs/presets/minimal.toml" in names
+        assert "configs/presets/balanced.toml" in names
+        assert "configs/presets/strict.toml" in names
+        assert "configs/presets/paranoid.toml" in names
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_install_cmd.py
+++ b/tests/test_install_cmd.py
@@ -149,7 +149,7 @@ class TestDeployGlobalConfigs:
         """All 4 built-in preset TOML files should be deployed."""
         plsec_home = tmp_path / ".peerlabs" / "plsec"
         deploy_global_configs(plsec_home, agents=AGENTS)
-        preset_dir = plsec_home / "config" / "presets"
+        preset_dir = plsec_home / "configs" / "presets"
         assert preset_dir.is_dir()
         for name in ("minimal.toml", "balanced.toml", "strict.toml", "paranoid.toml"):
             assert (preset_dir / name).exists(), f"Missing preset: {name}"
@@ -158,7 +158,7 @@ class TestDeployGlobalConfigs:
         """Deployed preset files should not be empty."""
         plsec_home = tmp_path / ".peerlabs" / "plsec"
         deploy_global_configs(plsec_home, agents=AGENTS)
-        preset_dir = plsec_home / "config" / "presets"
+        preset_dir = plsec_home / "configs" / "presets"
         for name in ("minimal.toml", "balanced.toml", "strict.toml", "paranoid.toml"):
             content = (preset_dir / name).read_text()
             assert len(content) > 0, f"Empty preset: {name}"
@@ -168,7 +168,7 @@ class TestDeployGlobalConfigs:
         """Preset files should not be overwritten without --force."""
         plsec_home = tmp_path / ".peerlabs" / "plsec"
         deploy_global_configs(plsec_home, agents=AGENTS)
-        marker_file = plsec_home / "config" / "presets" / "balanced.toml"
+        marker_file = plsec_home / "configs" / "presets" / "balanced.toml"
         marker_file.write_text("custom preset\n")
         deploy_global_configs(plsec_home, agents=AGENTS)
         assert marker_file.read_text() == "custom preset\n"
@@ -177,17 +177,17 @@ class TestDeployGlobalConfigs:
         """Preset files should be overwritten with --force."""
         plsec_home = tmp_path / ".peerlabs" / "plsec"
         deploy_global_configs(plsec_home, agents=AGENTS)
-        marker_file = plsec_home / "config" / "presets" / "balanced.toml"
+        marker_file = plsec_home / "configs" / "presets" / "balanced.toml"
         marker_file.write_text("custom preset\n")
         deploy_global_configs(plsec_home, force=True, agents=AGENTS)
         assert marker_file.read_text() != "custom preset\n"
 
     def test_creates_config_presets_subdirectory(self, tmp_path: Path):
-        """deploy_global_configs should create config/presets/ directory."""
+        """deploy_global_configs should create configs/presets/ directory."""
         plsec_home = tmp_path / ".peerlabs" / "plsec"
         deploy_global_configs(plsec_home, agents=AGENTS)
-        assert (plsec_home / "config").is_dir()
-        assert (plsec_home / "config" / "presets").is_dir()
+        assert (plsec_home / "configs").is_dir()
+        assert (plsec_home / "configs" / "presets").is_dir()
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -293,7 +293,7 @@ class TestResetCLI:
     def test_reset_redeploys_preset_files(self, tmp_path: Path):
         """Reset should redeploy preset TOML files after wipe."""
         plsec_home = self._setup_installed(tmp_path)
-        preset_dir = plsec_home / "config" / "presets"
+        preset_dir = plsec_home / "configs" / "presets"
         # Verify presets exist before reset
         assert (preset_dir / "balanced.toml").exists()
         # Corrupt a preset file

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -306,7 +306,7 @@ class TestUninstallCLI:
         """Uninstall --global should remove deployed preset TOML files."""
         plsec_home, project_dir = _setup_full_install(tmp_path)
         # Verify presets exist before uninstall
-        preset_dir = plsec_home / "config" / "presets"
+        preset_dir = plsec_home / "configs" / "presets"
         assert preset_dir.is_dir()
         assert (preset_dir / "balanced.toml").exists()
         with (


### PR DESCRIPTION
## Summary

Merges `~/.peerlabs/plsec/config/` into `~/.peerlabs/plsec/configs/`.
All user configuration now lives under a single directory.

Closes #13

## Before / After

| Before | After |
|---|---|
| `~/.peerlabs/plsec/configs/` (agent configs) | `~/.peerlabs/plsec/configs/` (all configs) |
| `~/.peerlabs/plsec/config/presets/` (presets) | `~/.peerlabs/plsec/configs/presets/` |

## Files changed

- `src/plsec/commands/install.py` — preset dest path
- `src/plsec/core/presets.py` — user preset dir path + docstrings
- `src/plsec/core/config.py` — docstring
- `src/plsec/core/health.py` — PLSEC_SUBDIRS and PLSEC_EXPECTED_PRESETS
- `tests/test_health.py` — preset path assertions
- `tests/test_install_cmd.py` — 6 preset path references
- `tests/test_reset.py` — preset path reference
- `tests/test_uninstall.py` — preset path reference

## Migration

Existing installations should run `plsec install --force` to create
the new directory structure.